### PR TITLE
Update CallNode.css to remove the second horizontal line on stack chart tooltip

### DIFF
--- a/src/components/tooltip/CallNode.css
+++ b/src/components/tooltip/CallNode.css
@@ -4,6 +4,8 @@
 
 .tooltipCallNodeImplementation {
   display: grid;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--grey-30);
   grid-gap: 2px;
   grid-template-columns: repeat(4, min-content);
 }
@@ -69,6 +71,4 @@
   min-width: 150px;
   padding: 10px;
   padding-bottom: 5px;
-  margin-top: 10px;
-  border-top: 1px solid var(--grey-30);
 }


### PR DESCRIPTION
Made changes as suggested in [#1807](https://github.com/firefox-devtools/profiler/pull/1807)